### PR TITLE
Add water type sex access repo tests

### DIFF
--- a/src/test/java/org/example/fishtank/repository/AccessRepositoryTest.java
+++ b/src/test/java/org/example/fishtank/repository/AccessRepositoryTest.java
@@ -1,0 +1,59 @@
+package org.example.fishtank.repository;
+
+import org.example.fishtank.model.entity.Access;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import java.util.NoSuchElementException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@DataJpaTest
+@Testcontainers
+class AccessRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgisContainer = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:15-3.3")
+                    .asCompatibleSubstituteFor("postgres")
+    );
+
+    @Autowired
+    AccessRepository accessRepository;
+
+    @BeforeEach
+    void setUp() {
+        Access testAccess = new Access();
+        Access testAccess2 = new Access();
+
+        testAccess.setName("Standard");
+        testAccess2.setName("Premium");
+
+        accessRepository.save(testAccess);
+        accessRepository.save(testAccess2);
+    }
+
+    @Test
+    void findByNameShouldReturnAccessWithSameName() {
+        String expectedName = "Standard";
+
+        String actualName = accessRepository.findByName("Standard").get().getName();
+
+        assertThat(expectedName).isEqualTo(actualName);
+    }
+
+
+    @Test
+    void findByNameShouldThrowExceptionIfNoAccessExist() {
+        assertThatThrownBy(() -> accessRepository.findByName("Test").get())
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessageContaining("No value present");
+    }
+}

--- a/src/test/java/org/example/fishtank/repository/SexRepositoryTest.java
+++ b/src/test/java/org/example/fishtank/repository/SexRepositoryTest.java
@@ -1,0 +1,58 @@
+package org.example.fishtank.repository;
+
+import org.example.fishtank.model.entity.Sex;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+@Testcontainers
+class SexRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgisContainer = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:15-3.3")
+                    .asCompatibleSubstituteFor("postgres")
+    );
+
+    @Autowired
+    SexRepository sexRepository;
+
+    @BeforeEach
+    void setUp() {
+        Sex textSex = new Sex();
+        Sex textSex2 = new Sex();
+
+        textSex.setName("Male");
+        textSex2.setName("Female");
+
+        sexRepository.save(textSex);
+        sexRepository.save(textSex2);
+    }
+
+    @Test
+    void findByNameShouldReturnSexWithSameName() {
+        String expectedName = "Male";
+
+        String actualName = sexRepository.findByName("Male").getName();
+
+        assertThat(expectedName).isEqualTo(actualName);
+    }
+
+    @Test
+    void findByNameShouldReturnNullIfSexNotExist() {
+        Sex expected = null;
+
+        Sex actual = sexRepository.findByName("Test");
+
+        assertThat(expected).isEqualTo(actual);
+    }
+}

--- a/src/test/java/org/example/fishtank/repository/WaterTypeRepositoryTest.java
+++ b/src/test/java/org/example/fishtank/repository/WaterTypeRepositoryTest.java
@@ -1,0 +1,59 @@
+package org.example.fishtank.repository;
+
+import org.example.fishtank.model.entity.WaterType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+@Testcontainers
+class WaterTypeRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgisContainer = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:15-3.3")
+                    .asCompatibleSubstituteFor("postgres")
+    );
+
+    @Autowired
+    WaterTypeRepository waterTypeRepository;
+
+    @BeforeEach
+    void setUp() {
+        WaterType waterType = new WaterType();
+        WaterType waterType1 = new WaterType();
+
+        waterType.setName("Fresh Water");
+        waterType1.setName("Salt Water");
+
+        waterTypeRepository.save(waterType);
+        waterTypeRepository.save(waterType1);
+    }
+
+
+    @Test
+    void findByNameShouldReturnWaterTypeWithSameName() {
+        String expectedName = "Fresh Water";
+
+        String actualName = waterTypeRepository.findByName("Fresh Water").getName();
+
+        assertThat(expectedName).isEqualTo(actualName);
+    }
+
+    @Test
+    void findByNameShouldReturnNullIfWaterTypeNotExist() {
+        WaterType expected = null;
+
+        WaterType actual = waterTypeRepository.findByName("Test Water");
+
+        assertThat(expected).isEqualTo(actual);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify correct behavior when querying by name in Access, Sex, and Water Type repositories.
  - Tests cover both successful lookups and cases where no matching entity exists, ensuring accurate repository responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->